### PR TITLE
Rename dscheduler/dworker to dask-scheduler/dask-worker

### DIFF
--- a/dask_ec2/cli/daskd.py
+++ b/dask_ec2/cli/daskd.py
@@ -50,7 +50,7 @@ def dask_install(ctx, filepath, shell, nprocs):
     scheduler_public_ip = cluster.instances[0].ip
     upload_pillar(cluster, "dask.sls", {"dask": {
                                             "scheduler_public_ip": scheduler_public_ip,
-                                            "dworker": {
+                                            "dask-worker": {
                                                 "nprocs": nprocs
                                             }
                                         }})

--- a/dask_ec2/formulas/salt/dask/distributed/scheduler/init.sls
+++ b/dask_ec2/formulas/salt/dask/distributed/scheduler/init.sls
@@ -4,26 +4,26 @@ include:
   - supervisor
   - dask.distributed
 
-dscheduler.conf:
+dask-scheduler.conf:
   file.managed:
-    - name: {{ conf_d }}/dscheduler.conf
-    - source: salt://dask/distributed/templates/dscheduler.conf
+    - name: {{ conf_d }}/dask-scheduler.conf
+    - source: salt://dask/distributed/templates/dask-scheduler.conf
     - template: jinja
     - makedirs: true
     - require:
       - sls: supervisor
       - sls: dask.distributed
 
-dscheduler-update-supervisor:
+dask-scheduler-update-supervisor:
   cmd.wait:
     - name: {{ supervisorctl }} -c {{ supervisord_conf }} update && sleep 2
     - watch:
-      - file: dscheduler.conf
+      - file: dask-scheduler.conf
 
-dscheduler-running:
+dask-scheduler-running:
   supervisord.running:
-    - name: dscheduler
+    - name: dask-scheduler
     - watch:
       - sls: dask.distributed
-      - file: dscheduler.conf
-      - cmd: dscheduler-update-supervisor
+      - file: dask-scheduler.conf
+      - cmd: dask-scheduler-update-supervisor

--- a/dask_ec2/formulas/salt/dask/distributed/settings.sls
+++ b/dask_ec2/formulas/salt/dask/distributed/settings.sls
@@ -11,4 +11,4 @@
 {% set roles = grains['roles'] %}
 {% set is_scheduler = 'dask.distributed.scheduler' in roles %}
 {% set is_worker = 'dask.distributed.worker' in roles %}
-{% set nprocs = salt['pillar.get']('dask:dworker:nprocs', 1)  %}
+{% set nprocs = salt['pillar.get']('dask:dask-worker:nprocs', 1)  %}

--- a/dask_ec2/formulas/salt/dask/distributed/templates/dask-scheduler.conf
+++ b/dask_ec2/formulas/salt/dask/distributed/templates/dask-scheduler.conf
@@ -1,18 +1,18 @@
 {%- from 'conda/settings.sls' import install_prefix with context -%}
-{%- from 'dask/distributed/settings.sls' import scheduler_host, nprocs with context -%}
+{%- from 'dask/distributed/settings.sls' import scheduler_public_ip with context -%}
 
 {%- set environment = [] -%}
 {%- do environment.append('LC_ALL="C.UTF-8"') -%}
 {%- do environment.append('LANG="C.UTF-8"') -%}
 {%- do environment.append('PATH="' ~ install_prefix ~ '/bin:%(ENV_PATH)s"') -%}
 
-[program:dworker]
-command={{ install_prefix }}/bin/python {{ install_prefix }}/bin/dworker {{ scheduler_host }}:8786 --nprocs {{nprocs}}
+[program:dask-scheduler]
+command={{ install_prefix }}/bin/python {{ install_prefix }}/bin/dask-scheduler --host {{ scheduler_public_ip }}
 startsecs=1
 numprocs=1
 autostart=false
 autorestart=true
-stdout_logfile=/var/log/dworker.log
+stdout_logfile=/var/log/dask-scheduler.log
 stdout_logfile_maxbytes=50MB
 redirect_stderr=true
 environment={{ environment | join(',') }}

--- a/dask_ec2/formulas/salt/dask/distributed/templates/dask-worker.conf
+++ b/dask_ec2/formulas/salt/dask/distributed/templates/dask-worker.conf
@@ -1,18 +1,18 @@
 {%- from 'conda/settings.sls' import install_prefix with context -%}
-{%- from 'dask/distributed/settings.sls' import scheduler_public_ip with context -%}
+{%- from 'dask/distributed/settings.sls' import scheduler_host, nprocs with context -%}
 
 {%- set environment = [] -%}
 {%- do environment.append('LC_ALL="C.UTF-8"') -%}
 {%- do environment.append('LANG="C.UTF-8"') -%}
 {%- do environment.append('PATH="' ~ install_prefix ~ '/bin:%(ENV_PATH)s"') -%}
 
-[program:dscheduler]
-command={{ install_prefix }}/bin/python {{ install_prefix }}/bin/dscheduler --host {{ scheduler_public_ip }}
+[program:dask-worker]
+command={{ install_prefix }}/bin/python {{ install_prefix }}/bin/dask-worker {{ scheduler_host }}:8786 --nprocs {{nprocs}}
 startsecs=1
 numprocs=1
 autostart=false
 autorestart=true
-stdout_logfile=/var/log/dscheduler.log
+stdout_logfile=/var/log/dask-worker.log
 stdout_logfile_maxbytes=50MB
 redirect_stderr=true
 environment={{ environment | join(',') }}

--- a/dask_ec2/formulas/salt/dask/distributed/worker/init.sls
+++ b/dask_ec2/formulas/salt/dask/distributed/worker/init.sls
@@ -4,26 +4,26 @@ include:
   - supervisor
   - dask.distributed
 
-dworker.conf:
+dask-worker.conf:
   file.managed:
-    - name: {{ conf_d }}/dworker.conf
-    - source: salt://dask/distributed/templates/dworker.conf
+    - name: {{ conf_d }}/dask-worker.conf
+    - source: salt://dask/distributed/templates/dask-worker.conf
     - template: jinja
     - makedirs: true
     - require:
       - sls: supervisor
       - sls: dask.distributed
 
-dworker-update-supervisor:
+dask-worker-update-supervisor:
   cmd.wait:
     - name: {{ supervisorctl }} -c {{ supervisord_conf }} update && sleep 2
     - watch:
-      - file: dworker.conf
+      - file: dask-worker.conf
 
-dworker-running:
+dask-worker-running:
   supervisord.running:
-    - name: dworker
+    - name: dask-worker
     - watch:
       - sls: dask.distributed
-      - file: dworker.conf
-      - cmd: dworker-update-supervisor
+      - file: dask-worker.conf
+      - cmd: dask-worker-update-supervisor


### PR DESCRIPTION
We've stopped supporting the dworker/dscheduler command line executables.