### PR TITLE
Feature/source install

### DIFF
--- a/dask_ec2/cli/daskd.py
+++ b/dask_ec2/cli/daskd.py
@@ -20,10 +20,15 @@ from ..salt import upload_pillar
               show_default=True,
               required=False,
               help="Number of processes per worker")
+@click.option("--source/--no-source",
+              is_flag=True,
+              default=False,
+              show_default=True,
+              help="Install Dask/Distributed from git master")
 @click.pass_context
-def dask(ctx, filepath, nprocs):
+def dask(ctx, filepath, nprocs, source):
     if ctx.invoked_subcommand is None:
-        ctx.invoke(dask_install, filepath=filepath, nprocs=nprocs)
+        ctx.invoke(dask_install, filepath=filepath, nprocs=nprocs, source=source)
 
 
 @dask.command("install", short_help="Start a dask.distributed cluster")
@@ -45,11 +50,17 @@ def dask(ctx, filepath, nprocs):
               show_default=True,
               required=False,
               help="Number of processes per worker")
-def dask_install(ctx, filepath, shell, nprocs):
+@click.option("--source/--no-source",
+              is_flag=True,
+              default=False,
+              show_default=True,
+              help="Install Dask/Distributed from git master")
+def dask_install(ctx, filepath, shell, nprocs, source):
     cluster = Cluster.from_filepath(filepath)
     scheduler_public_ip = cluster.instances[0].ip
     upload_pillar(cluster, "dask.sls", {"dask": {
                                             "scheduler_public_ip": scheduler_public_ip,
+                                            "source_install": source,
                                             "dask-worker": {
                                                 "nprocs": nprocs
                                             }

--- a/dask_ec2/cli/main.py
+++ b/dask_ec2/cli/main.py
@@ -131,8 +131,14 @@ def cli(ctx):
               show_default=True,
               required=False,
               help="Number of processes per worker")
+@click.option("--source/--no-source",
+              is_flag=True,
+              default=False,
+              show_default=True,
+              help="Install Dask/Distributed from git master")
 def up(ctx, name, keyname, keypair, region_name, vpc_id, subnet_id, ami, username, instance_type, count,
-       security_group_name, security_group_id, volume_type, volume_size, filepath, _provision, anaconda_, dask, notebook, nprocs):
+       security_group_name, security_group_id, volume_type, volume_size, filepath, _provision, anaconda_,
+       dask, notebook, nprocs, source):
     import os
     import yaml
     from ..ec2 import EC2
@@ -162,7 +168,8 @@ def up(ctx, name, keyname, keypair, region_name, vpc_id, subnet_id, ami, usernam
         yaml.safe_dump(cluster.to_dict(), f, default_flow_style=False)
 
     if _provision:
-        ctx.invoke(provision, filepath=filepath, anaconda_=anaconda_, dask=dask, notebook=notebook, nprocs=nprocs)
+        ctx.invoke(provision, filepath=filepath, anaconda_=anaconda_, dask=dask,
+                   notebook=notebook, nprocs=nprocs, source=source)
 
 
 @cli.command(short_help="Destroy cluster")
@@ -277,7 +284,12 @@ def ssh(ctx, node, filepath):
               show_default=True,
               required=False,
               help="Number of processes per worker")
-def provision(ctx, filepath, ssh_check, master, minions, upload, anaconda_, dask, notebook, nprocs):
+@click.option("--source/--no-source",
+              is_flag=True,
+              default=False,
+              show_default=True,
+              help="Install Dask/Distributed from git master")
+def provision(ctx, filepath, ssh_check, master, minions, upload, anaconda_, dask, notebook, nprocs, source):
     import six
     from ..salt import install_salt_master, install_salt_minion, upload_formulas, upload_pillar
 
@@ -306,7 +318,7 @@ def provision(ctx, filepath, ssh_check, master, minions, upload, anaconda_, dask
         ctx.invoke(anaconda, filepath=filepath)
     if dask:
         from .daskd import dask_install
-        ctx.invoke(dask_install, filepath=filepath, nprocs=nprocs)
+        ctx.invoke(dask_install, filepath=filepath, nprocs=nprocs, source=source)
     if notebook:
         ctx.invoke(notebook_install, filepath=filepath)
 

--- a/dask_ec2/formulas/salt/dask/distributed/init.sls
+++ b/dask_ec2/formulas/salt/dask/distributed/init.sls
@@ -1,4 +1,5 @@
 {%- from 'conda/settings.sls' import install_prefix with context -%}
+{%- from 'dask/distributed/settings.sls' import source_install with context -%}
 
 include:
   - conda
@@ -18,9 +19,27 @@ bokeh-install:
 
 dask-install:
   cmd.run:
-    - name: {{ install_prefix }}/bin/conda install dask distributed -y -q -c conda-forge
+    - name: {{ install_prefix }}/bin/conda install dask distributed fastparquet -y -q -c conda-forge
     - require:
       - sls: conda
+
+{% if source_install %}
+# install dask (above) to get dependencies then install from git
+source-dask-install:
+  pip.installed:
+    - name: git+https://github.com/dask/dask
+    - bin_env: {{ install_prefix }}/bin/pip
+    - require:
+      - sls: conda
+
+source-distributed-install:
+  pip.installed:
+    - name: git+https://github.com/dask/distributed
+    - bin_env: {{ install_prefix }}/bin/pip
+    - require:
+      - sls: conda
+
+{% endif %}
 
 
 update-pandas:

--- a/dask_ec2/formulas/salt/dask/distributed/settings.sls
+++ b/dask_ec2/formulas/salt/dask/distributed/settings.sls
@@ -12,3 +12,4 @@
 {% set is_scheduler = 'dask.distributed.scheduler' in roles %}
 {% set is_worker = 'dask.distributed.worker' in roles %}
 {% set nprocs = salt['pillar.get']('dask:dask-worker:nprocs', 1)  %}
+{% set source_install = salt['pillar.get']('dask:source_install', false)  %}


### PR DESCRIPTION
Resolves #47.  When user now issue the following optional flag `--source`, Dask and Distributed will be install from git master:

> dask-ec2 up --keyname KEYNAME --keypair ~/.ssh/KEYNAME.key --source

@mrocklin @danielfrg i'm not happy with the flag name.  Do you have other suggestions?  Internally, this is represented with the variable name: `source_install`
