### PR TITLE
Change default volume size to 8GB

### DIFF
--- a/dask_ec2/cli/main.py
+++ b/dask_ec2/cli/main.py
@@ -93,7 +93,7 @@ def cli(ctx):
               required=False,
               help="Root volume type")
 @click.option("--volume-size",
-              default=500,
+              default=8,
               show_default=True,
               required=False,
               help="Root volume size (GB)")


### PR DESCRIPTION
The default 500GB is far to large in my opinion and leads to large EBS charges.

The new 8GB default should be enough for most workloads an matches what is the default on EC2