### PR TITLE
Save cluster region on creation

### DIFF
--- a/ci/cluster_docker.yaml
+++ b/ci/cluster_docker.yaml
@@ -1,3 +1,4 @@
+region: foo
 instances:
 - ip: ci_head_1
   keypair: ~/.vagrant.d/insecure_private_key

--- a/ci/cluster_vagrant.yaml
+++ b/ci/cluster_vagrant.yaml
@@ -1,3 +1,4 @@
+region: foo
 instances:
 - ip: 127.0.0.1
   keypair: ~/.vagrant.d/insecure_private_key

--- a/dask_ec2/cli/main.py
+++ b/dask_ec2/cli/main.py
@@ -186,19 +186,14 @@ def up(ctx, name, keyname, keypair, region_name, vpc_id, subnet_id,
               required=False,
               help="Filepath to the instances metadata")
 @click.option('--yes', '-y', is_flag=True, default=False, help='Answers yes to questions')
-@click.option("--region-name",
-              default="us-east-1",
-              show_default=True,
-              required=False,
-              help="AWS region")
-def destroy(ctx, filepath, yes, region_name):
+def destroy(ctx, filepath, yes):
     import os
     from ..ec2 import EC2
     cluster = Cluster.from_filepath(filepath)
 
     question = 'Are you sure you want to destroy the cluster?'
     if yes or click.confirm(question):
-        driver = EC2(region=region_name, default_vpc=False, default_subnet=False)
+        driver = EC2(region=cluster.region, default_vpc=False, default_subnet=False)
         #needed if there is no default vpc or subnet
         ids = [i.uid for i in cluster.instances]
         click.echo("Terminating instances")

--- a/dask_ec2/cli/main.py
+++ b/dask_ec2/cli/main.py
@@ -168,8 +168,7 @@ def up(ctx, name, keyname, keypair, region_name, vpc_id, subnet_id,
     cluster = Cluster.from_boto3_instances(region_name, instances)
     cluster.set_username(username)
     cluster.set_keypair(keypair)
-    with open(filepath, "w") as f:
-        yaml.safe_dump(cluster.to_dict(), f, default_flow_style=False)
+    cluster.to_file(filepath)
 
     if _provision:
         ctx.invoke(provision, filepath=filepath, anaconda_=anaconda_, dask=dask,

--- a/dask_ec2/cli/main.py
+++ b/dask_ec2/cli/main.py
@@ -165,7 +165,7 @@ def up(ctx, name, keyname, keypair, region_name, vpc_id, subnet_id,
                               volume_size=volume_size,
                               keypair=keypair)
 
-    cluster = Cluster.from_boto3_instances(instances)
+    cluster = Cluster.from_boto3_instances(region_name, instances)
     cluster.set_username(username)
     cluster.set_keypair(keypair)
     with open(filepath, "w") as f:

--- a/dask_ec2/cluster.py
+++ b/dask_ec2/cluster.py
@@ -15,13 +15,14 @@ logger = logging.getLogger(__name__)
 
 class Cluster(object):
 
-    def __init__(self, instances=None):
+    def __init__(self, region, instances=None):
         self._pepper = None
+        self.region = region
         self.instances = instances or []
 
     @classmethod
-    def from_boto3_instances(cls, instances):
-        self = cls()
+    def from_boto3_instances(cls, region, instances):
+        self = cls(region)
         for boto3_instance in instances:
             instance = Instance.from_boto3_instance(boto3_instance)
             self.append(instance)
@@ -35,7 +36,7 @@ class Cluster(object):
 
     @classmethod
     def from_dict(cls, data):
-        self = cls()
+        self = cls(data["region"])
         instances = data["instances"]
         for instance in instances:
             self.instances.append(Instance.from_dict(instance))
@@ -90,6 +91,7 @@ class Cluster(object):
 
     def to_dict(self):
         ret = {}
+        ret["region"] = self.region
         ret["instances"] = []
         for instance in self.instances:
             ret["instances"].append(instance.to_dict())

--- a/dask_ec2/tests/test_cluster.py
+++ b/dask_ec2/tests/test_cluster.py
@@ -10,12 +10,12 @@ from .utils import remotetest, cluster, driver
 
 
 def test_cluster():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     assert len(cluster.instances) == 0
 
 
 def test_append_instance():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     n = 5
     for i in range(n):
         instance = Instance(ip="%i" % i)
@@ -26,13 +26,13 @@ def test_append_instance():
 
 
 def test_append_non_instance_type():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     with pytest.raises(DaskEc2Exception) as excinfo:
         cluster.append({"wrong": "type"})
 
 
 def test_set_username():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     n = 5
     for i in range(n):
         instance = Instance(ip="%i" % i)
@@ -47,7 +47,7 @@ def test_set_username():
 
 
 def test_set_keypair():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     n = 5
     for i in range(n):
         instance = Instance(ip="%i" % i)
@@ -62,7 +62,7 @@ def test_set_keypair():
 
 
 def test_dict_serde():
-    cluster = Cluster()
+    cluster = Cluster("foo")
     username = "user"
     keypair="~/.ssh/key"
     n = 5
@@ -87,7 +87,7 @@ def test_from_filepath(request, tmpdir):
     tempdir = tmpdir.mkdir("rootdir")
     fpath = os.path.join(tempdir.strpath, "{}.yaml".format(testname))
 
-    cluster = Cluster()
+    cluster = Cluster("foo")
     username = "user"
     keypair="~/.ssh/key"
     n = 5
@@ -122,6 +122,7 @@ def test_from_boto3(driver):
     name = "test_launch"
     ami = "ami-d05e75b8"
     instance_type = "m3.2xlarge"
+    region = "us-east-1"
     count = 5
     keyname = "mykey"
     keypair = None    # Skip check
@@ -141,4 +142,4 @@ def test_from_boto3(driver):
                               keypair=keypair,
                               check_ami=False)
 
-    instance = Cluster.from_boto3_instances(instances)
+    instance = Cluster.from_boto3_instances(region, instances)


### PR DESCRIPTION
When creating a cluster, the region is serialized to cluster.yaml so that we do not have to provide it when destroying the cluster.

Fixes #35.