### PR TITLE
The %%time magic requires that there be nothing else after it.

### DIFF
--- a/notebooks/01-custom-delayed.ipynb
+++ b/notebooks/01-custom-delayed.ipynb
@@ -102,6 +102,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling these lazy functions is now almost free.  We're just constructing a graph"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -109,7 +116,7 @@
    },
    "outputs": [],
    "source": [
-    "%%time  # Calling these lazy functions is now almost free.  We're just constructing a graph\n",
+    "%%time\n",
     "x = inc(1)\n",
     "y = dec(2)\n",
     "z = add(x, y)\n",


### PR DESCRIPTION
This moves the text that was a comment after the magic invocation to a markdown cell right before it. 